### PR TITLE
Install standard.js and run it before hoodie starts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "prestart": "node ./node_modules/webpack/bin/webpack.js --progress --colors",
-    "start": "nodemon index.js",
+    "start": "standard && nodemon index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -29,6 +29,7 @@
     "babel-loader": "^6.2.5",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
+    "standard": "^8.5.0",
     "webpack": "^1.13.3",
     "webpack-dev-server": "^1.16.2"
   }


### PR DESCRIPTION
I noticed that you use JavaScript without semicolons. That is fine, my only advice here is to use a linting tool which assists you here, because JavaScript has some odd behaviors when used without semicolons. 
This PR adds [standard.js](https://github.com/feross/standard) which runs before the application runs. If it finds anything, hoodie won't start. But the cool thing is, it can automatically fix things on its own \o/