### PR TITLE
Improved Webpack speed

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -2,17 +2,13 @@
 	"restartable": "rs",
 	"ignore": [
 		".git",
-		"node_modules/**/node_modules"
-	],
-	"verbose": true,
-	"watch": [
+		"node_modules/**/node_modules",
+		"public",
 		"src"
 	],
-	"events": {
-		"restart": "node ./node_modules/webpack/bin/webpack.js --progress --colors"
-	},
+	"verbose": true,
 	"env": {
 		"NODE_ENV": "development"
 	},
-	"ext": "js json"
+	"ext": "js"
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Projekt von Studentinnen der HTW Berlin, Wintersemester 2016/17.",
   "main": "index.js",
   "scripts": {
-    "prestart": "webpack --progress --colors",
-    "start": "nodemon index.js",
+    "start": "webpack --progress --colors --watch",
+    "server": "nodemon ./index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,10 +12,12 @@ module.exports = {
     loaders: [
       {
         test: /\.js$/,
+        exclude: /node_modules/,
         loaders: ['babel']
       },
       {
         include: /\.json$/,
+        exclude: /node_modules/,
         loaders: ["json-loader"]
       }
     ]


### PR DESCRIPTION
**commit 2:** excludes the node_modules folder from webpack => improves speed

run `npm run prestart | gnomon`
([gnomon](https://github.com/paypal/gnomon) is used to measure the time)

default (your current webpack config) 
```
11.9010s
10.2517s
10.1898s
```

with node_modules folder excluded (commit 2)
```
4.6893s
4.3650s
4.5655s
```

with [happipack](https://github.com/amireh/happypack )
```
2.7235s
2.8126s
```
> HappyPack makes webpack builds faster by allowing you to transform multiple files in parallel.

_But it might not work under Windows so I’m not adding it into the PR._


----

**commit 1:** I would advise you to split the server (nodemon) and the front-end (webpack) into independent tasks.
Webpack has the watch feature and this should result in faster build times

Instead of  `npm start` you just have to run:
`npm start` to run web pack and
 `npm run server`  to start the server


If you have issues that the server is restarting multiple times for one change you might want to delay the restart:
`nodemon --delay 3 ./index.js`