### PR TITLE
Improve Hover-Effect on Modules

### DIFF
--- a/public/css/custom-style.css
+++ b/public/css/custom-style.css
@@ -3,9 +3,7 @@
 }
 
 .grow { transition: all .2s ease-in-out; }
-.grow:hover {
-  transform: scale(1.1);
-}
+.grow:hover { transform: scale(1.1); }
 
 .default-cursor { cursor: default; }
 

--- a/public/css/custom-style.css
+++ b/public/css/custom-style.css
@@ -5,6 +5,13 @@
 .grow { transition: all .2s ease-in-out; }
 .grow:hover { transform: scale(1.1); }
 
+button:hover,
+.button:hover {
+  color: #555;
+  border-color: #bbb;
+  outline: 0;
+}
+
 .default-cursor { cursor: default; }
 
 .fix{
@@ -22,6 +29,10 @@
 .grey { background-color: #AFAFAF; }
 .blue {
   background-color: #0082D1;
+  color: #FFFFF0;
+}
+
+.blue:hover {
   color: #FFFFF0;
 }
 

--- a/public/css/custom-style.css
+++ b/public/css/custom-style.css
@@ -2,9 +2,13 @@
   display: inline;
 }
 
-.hover:hover {
-  background-color: #76B900;
+.grow { transition: all .2s ease-in-out; }
+.grow:hover {
+  transform: scale(1.1);
 }
+
+.default-cursor { cursor: default; }
+
 .fix{
   background-color: #76B900;
   padding-top: auto;
@@ -18,9 +22,9 @@
 .red { background-color: #FF5F00; }
 .yellow { background-color: #FFFF66; }
 .grey { background-color: #AFAFAF; }
-.blue { 
-  background-color: #0082D1; 
-  color: #FFFFF0; 
+.blue {
+  background-color: #0082D1;
+  color: #FFFFF0;
 }
 
 .button{
@@ -85,7 +89,7 @@ div.flex-container{
 
 .flex-item{
   vertical-align: center;
-  -webkit-align-self: center; 
+  -webkit-align-self: center;
   align-self: center;
   margin-top: 10px;
   padding-bottom: 0px;
@@ -106,8 +110,8 @@ div.flex-container{
 
 *{
 -webkit-box-sizing: border-box;
--moz-box-sizing: border-box; 
--ms-box-sizing: border-box; 
+-moz-box-sizing: border-box;
+-ms-box-sizing: border-box;
 box-sizing: border-box;
 }
 
@@ -136,30 +140,30 @@ section#symbology{
 .selected,
 .selected_urgent{
   border: 1px solid grey;
-  border-radius: 5px; 
+  border-radius: 5px;
   width: 70px;
   height: 30px;
   margin: auto;
 }
 
 .available{
-  background-color: #0082D1;  
+  background-color: #0082D1;
  }
 .started{
-  background-color: #FFFF66;  
+  background-color: #FFFF66;
 }
 .completed{
-  background-color: #AFAFAF; 
+  background-color: #AFAFAF;
 }
 .urgent{
-  background-color: #FF5F00;  
+  background-color: #FF5F00;
 }
 .selected{
-  background-color: #76B900;  
+  background-color: #76B900;
 }
 .selected_urgent{
-  background-color: #76B900; 
-  border: 2px solid red; 
+  background-color: #76B900;
+  border: 2px solid red;
 }
 
 section#coursePlan{

--- a/public/css/skeleton.css
+++ b/public/css/skeleton.css
@@ -186,6 +186,11 @@ input[type="button"] {
   border: 1px solid #bbb;
   cursor: pointer;
   box-sizing: border-box; }
+.button:hover,
+button:hover,
+input[type="submit"]:hover,
+input[type="reset"]:hover,
+input[type="button"]:hover,
 .button:focus,
 button:focus,
 input[type="submit"]:focus,

--- a/public/css/skeleton.css
+++ b/public/css/skeleton.css
@@ -186,11 +186,6 @@ input[type="button"] {
   border: 1px solid #bbb;
   cursor: pointer;
   box-sizing: border-box; }
-.button:hover,
-button:hover,
-input[type="submit"]:hover,
-input[type="reset"]:hover,
-input[type="button"]:hover,
 .button:focus,
 button:focus,
 input[type="submit"]:focus,

--- a/src/Module.js
+++ b/src/Module.js
@@ -6,24 +6,24 @@ class Module extends React.Component {
   };
 
   render() {
-    var ModuleClasses = "button hover";
+    var ModuleClasses = "button";
     var ModuleClasses_fix = "fix";
 
     switch (this.props.userModule.status) {
       case "urgent":
-        ModuleClasses += " red";
+        ModuleClasses += " red grow";
         break;
       case "started":
-        ModuleClasses += " yellow";
+        ModuleClasses += " yellow grow";
         break;
       case "selected":
-        ModuleClasses += " green";
+        ModuleClasses += " green grow";
         break;
       case "completed":
-        ModuleClasses += " grey";
+        ModuleClasses += " grey default-cursor";
         break;
       default:
-        ModuleClasses += " blue";
+        ModuleClasses += " blue grow";
     }
 
     return (

--- a/src/ModulePool.js
+++ b/src/ModulePool.js
@@ -10,7 +10,7 @@ class ModulePool extends React.Component {
   	return this.props.retrieveSelectedModules.map((module) => {
       return(
         <div>
-        <a href="#" onClick={_this.toggleModule.bind(_this, module)} className="button fix" key={module.title}>{module.title}</a>
+        <div onClick={_this.toggleModule.bind(_this, module)} className="button fix" key={module.title}>{module.title}</div>
         <br />
         </div>
         );
@@ -22,7 +22,7 @@ class ModulePool extends React.Component {
       <div id="coursePool" className="float-right">
         <div className="bordertype">
           <div id="main"> {this.renderModules()}</div>
-         </div> 
+         </div>
       </div>
     )
   }


### PR DESCRIPTION
I removed the green hover effect and add a transition instead. Also removed the hand cursor from completed /grey) modules.
For proper hover effect I had to delete the button:hover method from skeleton. I don't know if that's the best way to do it, but we don't need the styling anywhere else so far.
I also switched the module in the PlanningSection from 'a' to 'div', for suppressing the typical blue hover-effect on a link.

@lauralindal and @lenakoester please take a look :)